### PR TITLE
Use DownloadManager in PlayButton and show ratings on home posters

### DIFF
--- a/Shared/Components/PosterIndicators/RatingIndicator.swift
+++ b/Shared/Components/PosterIndicators/RatingIndicator.swift
@@ -1,0 +1,38 @@
+//
+// Swiftfin is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2025 Jellyfin & Jellyfin Contributors
+//
+
+import SwiftUI
+
+struct RatingIndicator: View {
+
+    let rating: Double
+
+    private var ratingText: String {
+        String(format: "%.1f", rating)
+    }
+
+    var body: some View {
+        ZStack(alignment: .topLeading) {
+            Color.clear
+
+            HStack(spacing: 2) {
+                Image(systemName: "star.fill")
+                    .font(.caption2)
+                Text(ratingText)
+                    .font(.caption2)
+                    .fontWeight(.semibold)
+            }
+            .padding(.vertical, 2)
+            .padding(.horizontal, 4)
+            .background(Color.black.opacity(0.7))
+            .foregroundColor(.yellow)
+            .clipShape(RoundedRectangle(cornerRadius: 3))
+            .padding(5)
+        }
+    }
+}

--- a/Swiftfin/Components/PosterButton.swift
+++ b/Swiftfin/Components/PosterButton.swift
@@ -243,6 +243,12 @@ extension PosterButton {
                         FavoriteIndicator(size: 25)
                             .isVisible(showFavorited)
                     }
+
+                    if (item.type == .movie || item.type == .series),
+                       let rating = item.communityRating
+                    {
+                        RatingIndicator(rating: rating)
+                    }
                 }
             }
         }

--- a/Swiftfin/Views/HomeView/Components/ContinueWatchingView.swift
+++ b/Swiftfin/Views/HomeView/Components/ContinueWatchingView.swift
@@ -65,10 +65,14 @@ extension HomeView {
                 }
             }
             .posterOverlay(for: BaseItemDto.self) { item in
-                LandscapePosterProgressBar(
-                    title: item.progressLabel ?? L10n.continue,
-                    progress: (item.userData?.playedPercentage ?? 0) / 100
-                )
+                ZStack(alignment: .topLeading) {
+                    PosterButton<BaseItemDto>.DefaultOverlay(item: item)
+
+                    LandscapePosterProgressBar(
+                        title: item.progressLabel ?? L10n.continue,
+                        progress: (item.userData?.playedPercentage ?? 0) / 100
+                    )
+                }
             }
         }
     }

--- a/Swiftfin/Views/ItemView/Components/PlayButton.swift
+++ b/Swiftfin/Views/ItemView/Components/PlayButton.swift
@@ -7,6 +7,7 @@
 //
 
 import Defaults
+import Factory
 import JellyfinAPI
 import Logging
 import SwiftUI
@@ -20,6 +21,9 @@ extension ItemView {
 
         @Router
         private var router
+
+        @Injected(\.downloadManager)
+        private var downloadManager
 
         @ObservedObject
         var viewModel: ItemViewModel
@@ -109,14 +113,22 @@ extension ItemView {
                 playButtonItem.userData?.playbackPositionTicks = 0
             }
 
-            router.route(
-                to: .videoPlayer(
-                    manager: OnlineVideoPlayerManager(
-                        item: playButtonItem,
-                        mediaSource: selectedMediaSource
+            if let task = downloadManager.task(for: playButtonItem), case .complete = task.state {
+                router.route(
+                    to: .videoPlayer(
+                        manager: DownloadVideoPlayerManager(downloadTask: task)
                     )
                 )
-            )
+            } else {
+                router.route(
+                    to: .videoPlayer(
+                        manager: OnlineVideoPlayerManager(
+                            item: playButtonItem,
+                            mediaSource: selectedMediaSource
+                        )
+                    )
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- inject DownloadManager into PlayButton
- play offline downloads via DownloadVideoPlayerManager when available
- fallback to OnlineVideoPlayerManager otherwise
- display community ratings on home screen posters

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68baa41be37c832e9d342ccac35ec5e3